### PR TITLE
Adding support for end to end testing with or without ssh

### DIFF
--- a/src/cloudShell.ts
+++ b/src/cloudShell.ts
@@ -251,7 +251,6 @@ export class CloudShell extends BaseShell {
             case TestOption.lint:
                 return "rake -f ../../Rakefile build";
             case TestOption.e2enossh:
-                return "rake -f ../../Rakefile e2e";
             case TestOption.e2ewithssh:
                 return "rake -f ../../Rakefile e2e";
             case TestOption.custom:


### PR DESCRIPTION
I modified the scripts to add the support for end to end testing with cloudshell and reuse the authentication token from the cloudshell.
