### PR TITLE
fix the e2e test in cloud

### DIFF
--- a/src/cloudShell.ts
+++ b/src/cloudShell.ts
@@ -232,10 +232,10 @@ export class CloudShell extends BaseShell {
     private async resolveContainerCmd(TestType: string): Promise<string> {
         switch (TestType) {
             case TestOption.lint:
-                return "rake -f ../../Rakefile build";
+                return "rake -f ../Rakefile build";
             case TestOption.e2enossh:
             case TestOption.e2ewithssh:
-                return "rake -f ../../Rakefile e2e";
+                return "rake -f ../Rakefile e2e";
             case TestOption.custom:
                 const cmd: string = await vscode.window.showInputBox({
                     prompt: "Type your custom test command",

--- a/src/integratedShell.ts
+++ b/src/integratedShell.ts
@@ -70,7 +70,7 @@ export class IntegratedShell extends BaseShell {
                 console.log("Running e2e test in " + process.env["ARM_TEST_LOCATION"]);
                 await runE2EInDocker(
                     [
-                        workingDirectory + "/logs:/tf-test/module.kitchen",
+                        workingDirectory + "/logs:/tf-test/module/.kitchen",
                         workingDirectory + ":/tf-test/module",
                     ],
                     containerName,
@@ -82,7 +82,7 @@ export class IntegratedShell extends BaseShell {
                 await runE2EInDocker(
                     [
                         `${path.join(os.homedir(), ".ssh")}:/root/.ssh/`,
-                        workingDirectory + "/logs:/tf-test/module.kitchen",
+                        workingDirectory + "/logs:/tf-test/module/.kitchen",
                         workingDirectory + ":/tf-test/module",
                     ],
                     containerName,


### PR DESCRIPTION
- fix #65 , remove the mount volumn, which is no need. User can view the log by triggering `az container logs`
- fix other typos which breaks the e2e test feature.