### PR TITLE
Ask user to upload files once the cloud shell has been provisioned

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
                 "tf-azure.files": {
                     "type": "string",
                     "default": "**/*.{rb,sh,tf,tfvars,txt,yml}",
-                    "description": "Indicates the files that should be synchronized to Azure cloudshell using the glob pattern string, for example: **/*.{tf,txt,yml,tfvars,rb}"
+                    "description": "Indicates the files that should be synchronized to Azure Cloud Shell using the glob pattern string, for example: **/*.{tf,txt,yml,tfvars,rb}"
                 },
                 "tf-azure.test-container": {
                     "type": "string",

--- a/src/cloudShell.ts
+++ b/src/cloudShell.ts
@@ -42,14 +42,6 @@ export class CloudShell extends BaseShell {
 
     public async runTerraformTests(testType: string, workingDirectory: string) {
         if (await this.connectedToCloudShell()) {
-            const choice: vscode.MessageItem = await vscode.window.showInformationMessage(
-                "Would you like to push the terraform project files to CloudShell?",
-                DialogOption.OK,
-                DialogOption.CANCEL,
-            );
-            if (choice === DialogOption.OK) {
-                await vscode.commands.executeCommand("vscode-terraform-azure.push");
-            }
 
             const workspaceName: string = path.basename(workingDirectory);
             const setupFilesFolder: string = `${workspaceName}/.TFTesting`;
@@ -163,6 +155,15 @@ export class CloudShell extends BaseShell {
             this.tfTerminal.fileShareName = terminal[4];
             this.tfTerminal.ResourceGroup = terminal[5];
             terraformChannel.appendLine("Cloudshell terminal opened.");
+
+            const choice: vscode.MessageItem = await vscode.window.showInformationMessage(
+                "Would you like to push the terraform project files in current workspace to Cloud Shell?",
+                DialogOption.OK,
+                DialogOption.CANCEL,
+            );
+            if (choice === DialogOption.OK) {
+                await vscode.commands.executeCommand("vscode-terraform-azure.push");
+            }
             return true;
         }
 


### PR DESCRIPTION
When a new cloud shell is provisioned, we will ask user if he wants to push files onto the cloud shell.

This can prevent `No such file or directory` error when triggering terraform commands