### PR TITLE
Remove category 'Languages'

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     },
     "preview": true,
     "categories": [
-        "Programming Languages",
         "Azure",
         "Other"
     ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "preview": true,
     "categories": [
-        "Languages",
+        "Programming Languages",
         "Azure",
         "Other"
     ],


### PR DESCRIPTION
According to this issue: https://github.com/Microsoft/vscode/issues/47114

We need to change `Languages` to `Programming Languages`