### PR TITLE
Update vulnerable packages according to npm audit and internal discussion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "7.0.48"
+                "@types/node": "*"
             }
         },
         "@types/fs-extra": {
@@ -23,7 +23,7 @@
             "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.48"
+                "@types/node": "*"
             }
         },
         "@types/keytar": {
@@ -54,10 +54,10 @@
             "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
             "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "requires": {
-                "@types/caseless": "0.12.1",
-                "@types/form-data": "2.2.1",
-                "@types/node": "7.0.48",
-                "@types/tough-cookie": "2.3.2"
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
             }
         },
         "@types/semver": {
@@ -76,7 +76,7 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
             "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
             "requires": {
-                "@types/node": "7.0.48"
+                "@types/node": "*"
             }
         },
         "adal-node": {
@@ -84,33 +84,51 @@
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
             "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
             "requires": {
-                "@types/node": "8.9.5",
-                "async": "2.6.0",
-                "date-utils": "1.2.21",
-                "jws": "3.1.4",
-                "request": "2.83.0",
-                "underscore": "1.8.3",
-                "uuid": "3.1.0",
-                "xmldom": "0.1.27",
-                "xpath.js": "1.1.0"
+                "@types/node": "^8.0.47",
+                "async": ">=0.6.0",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "request": ">= 2.52.0",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.9.5",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
-                    "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ=="
+                    "version": "8.10.23",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.23.tgz",
+                    "integrity": "sha512-aEp5ZTLr4mYhR9S85cJ+sEYkcsgFY10N1Si5m49iTAVzanZXOwp/pgw6ibFLKXxpflqm71aSWZCRtnTXXO56gA=="
                 }
             }
         },
         "ajv": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-            "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+            }
+        },
+        "ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
             }
         },
         "ansi-regex": {
@@ -125,6 +143,12 @@
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
             "dev": true
         },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
+        },
         "applicationinsights": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz",
@@ -136,12 +160,13 @@
             }
         },
         "arr-diff": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+            "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -150,10 +175,22 @@
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
+        "arr-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+            "dev": true
+        },
         "array-differ": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
+        },
+        "array-slice": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
             "dev": true
         },
         "array-union": {
@@ -162,7 +199,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -184,21 +221,24 @@
             "dev": true
         },
         "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
         },
         "assert-plus": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "async": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.14.0"
             }
         },
         "async-listener": {
@@ -206,8 +246,8 @@
             "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
             "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
             "requires": {
-                "semver": "5.4.1",
-                "shimmer": "1.2.0"
+                "semver": "^5.3.0",
+                "shimmer": "^1.1.0"
             }
         },
         "asynckit": {
@@ -216,147 +256,40 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
         },
         "azure-arm-resource": {
             "version": "2.0.0-preview",
             "resolved": "https://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-2.0.0-preview.tgz",
             "integrity": "sha1-lYAQoY+V/4LpqZU3E7oMydJxEks=",
             "requires": {
-                "ms-rest": "2.3.2",
-                "ms-rest-azure": "2.5.5"
+                "ms-rest": "^2.0.0",
+                "ms-rest-azure": "^2.0.0"
             }
         },
         "azure-storage": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.8.0.tgz",
-            "integrity": "sha1-OtDZD0df+SCdZWWvPg7JxWQTBKQ=",
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.1.tgz",
+            "integrity": "sha512-rnFo1uMIPtilusRCpK91tfY3P4Q7qRsDNwriXdp+OeTIGkGt0cTxL4mhqYfNPYPK+WBQmBdGWhOk+iROM05dcw==",
             "requires": {
-                "browserify-mime": "1.2.9",
-                "extend": "1.2.1",
+                "browserify-mime": "~1.2.9",
+                "extend": "~1.2.1",
                 "json-edm-parser": "0.1.2",
                 "md5.js": "1.3.4",
-                "readable-stream": "2.0.6",
-                "request": "2.81.0",
-                "underscore": "1.8.3",
-                "uuid": "3.1.0",
-                "validator": "3.35.0",
+                "readable-stream": "~2.0.0",
+                "request": "^2.86.0",
+                "underscore": "~1.8.3",
+                "uuid": "^3.0.0",
+                "validator": "~9.4.1",
                 "xml2js": "0.2.8",
                 "xmlbuilder": "0.4.3"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-                },
-                "extend": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-                    "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                    "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                    }
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-                },
-                "qs": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-                },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "request": {
-                    "version": "2.81.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.1.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.1.0"
-                    },
-                    "dependencies": {
-                        "extend": {
-                            "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-                        }
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
-                }
             }
         },
         "babel-code-frame": {
@@ -365,9 +298,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "balanced-match": {
@@ -376,25 +309,14 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
-        "base64url": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-            "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-        },
         "bcrypt-pbkdf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
-        },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
         },
         "block-stream": {
             "version": "0.0.9",
@@ -402,7 +324,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -410,21 +332,13 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
             "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
-        "boom": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "requires": {
-                "hoek": "2.16.3"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -434,9 +348,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -461,6 +375,12 @@
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -468,10 +388,9 @@
             "dev": true
         },
         "caseless": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-            "dev": true
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
             "version": "1.1.3",
@@ -479,17 +398,17 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "clone": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
             "dev": true
         },
         "clone-buffer": {
@@ -505,14 +424,46 @@
             "dev": true
         },
         "cloneable-readable": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+            "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "1.0.7",
-                "through2": "2.0.3"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "co": {
@@ -526,7 +477,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -536,11 +487,11 @@
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -560,8 +511,8 @@
             "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
             "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
             "requires": {
-                "async-listener": "0.6.9",
-                "emitter-listener": "1.1.1"
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.1.1"
             }
         },
         "convert-source-map": {
@@ -575,39 +526,18 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "cryptiles": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "requires": {
-                "boom": "2.10.1"
-            }
-        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
+                "assert-plus": "^1.0.0"
             }
         },
         "date-utils": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
             "integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
-        },
-        "dateformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-            "dev": true
         },
         "debug": {
             "version": "3.1.0",
@@ -624,7 +554,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "delayed-stream": {
@@ -637,7 +567,7 @@
             "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
             "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
             "requires": {
-                "semver": "5.4.1"
+                "semver": "^5.3.0"
             }
         },
         "diagnostic-channel-publishers": {
@@ -656,69 +586,34 @@
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "1.1.14"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
         "duplexify": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-            "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ecdsa-sig-formatter": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-            "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+            "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
             "requires": {
-                "base64url": "2.0.0",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "emitter-listener": {
@@ -726,16 +621,16 @@
             "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.1.tgz",
             "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
             "requires": {
-                "shimmer": "1.2.0"
+                "shimmer": "^1.2.0"
             }
         },
         "end-of-stream": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-            "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -756,13 +651,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -771,7 +666,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -780,21 +675,21 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "extend": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+            "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
         },
         "extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+            "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "is-extendable": "0.1.1"
+                "kind-of": "^1.1.0"
             }
         },
         "extglob": {
@@ -803,7 +698,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -819,20 +714,10 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
-        "fancy-log": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "time-stamp": "1.1.0"
-            }
-        },
         "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -840,12 +725,12 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fd-slicer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -855,16 +740,16 @@
             "dev": true
         },
         "fill-range": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+            "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "first-chunk-stream": {
@@ -885,7 +770,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -894,13 +779,13 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -914,9 +799,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
             "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -931,25 +816,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-            }
-        },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "1.0.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "getpass": {
@@ -957,14 +827,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -973,12 +836,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -987,8 +850,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -997,7 +860,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -1012,7 +875,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1023,8 +886,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -1033,27 +896,33 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
+                "extend": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+                    "dev": true
+                },
                 "glob": {
                     "version": "5.0.15",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -1068,17 +937,11 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
                 },
                 "through2": {
                     "version": "0.6.5",
@@ -1086,19 +949,10 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
-            }
-        },
-        "glogg": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
             }
         },
         "graceful-fs": {
@@ -1118,20 +972,20 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.1.tgz",
-            "integrity": "sha512-5olRzAhFdXB2klCu1lnazP65aO9YdA/5WfC9VdInIc8PrUeDIoZfaA3Edb0yUBGhVdHv4eHKL9Fg5tUoEJ9z5A==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
+            "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "multimatch": "2.1.0",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -1140,16 +994,10 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
                 "isarray": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -1162,17 +1010,11 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
                 },
                 "through2": {
                     "version": "0.6.5",
@@ -1180,88 +1022,49 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
         },
-        "gulp-remote-src": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
-            "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+        "gulp-remote-src-vscode": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
+            "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
                 "clone-stats": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "2.79.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
-                    }
-                },
                 "vinyl": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
-                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1272,21 +1075,33 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
                 "vinyl": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1298,49 +1113,48 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
-            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
+            "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "dev": true,
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.0",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
             }
         },
         "gulp-vinyl-zip": {
@@ -1349,19 +1163,19 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
                 "clone-stats": {
@@ -1376,38 +1190,23 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
-                },
-                "replace-ext": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-                    "dev": true
                 },
                 "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
-            "requires": {
-                "glogg": "1.0.0"
             }
         },
         "har-schema": {
@@ -1416,15 +1215,12 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-            "dev": true,
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.12.2",
-                "is-my-json-valid": "2.16.1",
-                "pinkie-promise": "2.0.1"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -1433,7 +1229,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1442,33 +1238,13 @@
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
-            }
-        },
         "hash-base": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
-            }
-        },
-        "hawk": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "he": {
@@ -1477,19 +1253,14 @@
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
-        "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
         "http-signature": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1498,8 +1269,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1530,7 +1301,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1551,19 +1322,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
-            }
-        },
-        "is-my-json-valid": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-            "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-            "dev": true,
-            "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-number": {
@@ -1572,7 +1331,18 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "is-obj": {
@@ -1591,12 +1361,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
             "dev": true
         },
         "is-stream": {
@@ -1662,7 +1426,7 @@
             "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
             "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
             "requires": {
-                "jsonparse": "1.2.0"
+                "jsonparse": "~1.2.0"
             }
         },
         "json-schema": {
@@ -1679,8 +1443,9 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1693,24 +1458,19 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
         },
         "jsonparse": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
             "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
-        },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
         },
         "jsprim": {
             "version": "1.4.1",
@@ -1721,44 +1481,32 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "jwa": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-            "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+            "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
             "requires": {
-                "base64url": "2.0.0",
                 "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.9",
-                "safe-buffer": "5.1.1"
+                "ecdsa-sig-formatter": "1.0.10",
+                "safe-buffer": "^5.0.1"
             }
         },
         "jws": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-            "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+            "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
             "requires": {
-                "base64url": "2.0.0",
-                "jwa": "1.1.5",
-                "safe-buffer": "5.1.1"
+                "jwa": "^1.1.5",
+                "safe-buffer": "^5.0.1"
             }
         },
         "kind-of": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true,
-            "requires": {
-                "is-buffer": "1.1.6"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+            "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+            "dev": true
         },
         "lazystream": {
             "version": "1.0.0",
@@ -1766,88 +1514,13 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true,
-            "requires": {
-                "lodash._root": "3.0.1"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "lodash.isequal": {
             "version": "4.5.0",
@@ -1855,54 +1528,16 @@
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
             "dev": true
         },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true,
-            "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
-            }
-        },
         "map-stream": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
             "dev": true
         },
         "md5.js": {
@@ -1910,8 +1545,8 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "merge-stream": {
@@ -1920,7 +1555,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -1929,21 +1564,30 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.0.1"
+                    }
+                },
                 "is-extglob": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
@@ -1956,22 +1600,31 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
         },
         "mime-db": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-            "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+            "version": "1.35.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+            "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
         },
         "mime-types": {
-            "version": "2.1.17",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+            "version": "2.1.19",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+            "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.35.0"
             }
         },
         "minimatch": {
@@ -1980,13 +1633,13 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
         "mkdirp": {
@@ -1996,20 +1649,12 @@
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
-                }
             }
         },
         "mocha": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-            "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
             "dev": true,
             "requires": {
                 "browser-stdout": "1.3.0",
@@ -2036,7 +1681,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -2057,17 +1702,17 @@
             "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.3.2.tgz",
             "integrity": "sha512-48K1raGitFMs9lICjdDY1t/mcCClJDeaoAM5EZ7ST3o4pQGcxdKZNaoneKEwN0KfTHXDhAmxJ/B8LCZZ45K9CA==",
             "requires": {
-                "@types/node": "8.9.5",
-                "@types/request": "2.47.0",
-                "@types/uuid": "3.4.3",
-                "duplexer": "0.1.1",
-                "is-buffer": "1.1.6",
-                "is-stream": "1.1.0",
-                "moment": "2.21.0",
-                "request": "2.83.0",
-                "through": "2.3.8",
+                "@types/node": "^8.9.4",
+                "@types/request": "^2.47.0",
+                "@types/uuid": "^3.4.3",
+                "duplexer": "^0.1.1",
+                "is-buffer": "^1.1.6",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "request": "^2.83.0",
+                "through": "^2.3.8",
                 "tunnel": "0.0.5",
-                "uuid": "3.2.1"
+                "uuid": "^3.2.1"
             },
             "dependencies": {
                 "@types/node": {
@@ -2083,28 +1728,26 @@
             }
         },
         "ms-rest-azure": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.5.tgz",
-            "integrity": "sha512-LnP5YlgqvNAOi1x2b4Ru+1ubz/PtYQgNeH74aiolP+Sb5lpOw5ewzbncXae1pR5OWu9NGwxjX59adzSWosqnzw==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.7.tgz",
+            "integrity": "sha512-e4lgB0z29Dx4ufu/c+PmEAYY1WXq98GYUBkE+iRx7WsxsN04lrM3B1vj8y+B8rKt7clPUE0niqB9VovVL8zvag==",
             "requires": {
-                "@types/node": "9.4.7",
-                "@types/uuid": "3.4.3",
-                "adal-node": "0.1.28",
+                "adal-node": "^0.1.28",
                 "async": "2.6.0",
-                "moment": "2.21.0",
-                "ms-rest": "2.3.2",
-                "uuid": "3.2.1"
+                "moment": "^2.22.2",
+                "ms-rest": "^2.3.2",
+                "uuid": "^3.2.1"
             },
             "dependencies": {
-                "@types/node": {
-                    "version": "9.4.7",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
-                    "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw=="
+                "moment": {
+                    "version": "2.22.2",
+                    "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+                    "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
                 },
                 "uuid": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-                    "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
                 }
             }
         },
@@ -2114,19 +1757,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
-            }
-        },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.0.2"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "node.extend": {
@@ -2135,7 +1769,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -2144,7 +1778,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "oauth-sign": {
@@ -2153,9 +1787,9 @@
             "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "object-assign": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
         "object.omit": {
@@ -2164,8 +1798,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -2174,7 +1808,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "opn": {
@@ -2182,7 +1816,7 @@
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
             "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "ordered-read-streams": {
@@ -2191,8 +1825,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.3"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "parse-glob": {
@@ -2201,10 +1835,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2219,7 +1853,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2248,7 +1882,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -2262,19 +1896,17 @@
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "plugin-error": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "preserve": {
@@ -2294,15 +1926,14 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qs": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-            "dev": true
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "querystringify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+            "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
             "dev": true
         },
         "queue": {
@@ -2311,63 +1942,45 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "1.1.6"
-                            }
-                        }
-                    }
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
                 },
                 "kind-of": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
         "readable-stream": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-            "dev": true,
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+            "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regex-cache": {
@@ -2376,7 +1989,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -2398,146 +2011,42 @@
             "dev": true
         },
         "replace-ext": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
             "dev": true
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.87.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                },
-                "aws-sign2": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-                },
-                "boom": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-                    "requires": {
-                        "hoek": "4.2.0"
-                    }
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-                },
-                "cryptiles": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-                    "requires": {
-                        "boom": "5.2.0"
-                    },
-                    "dependencies": {
-                        "boom": {
-                            "version": "5.2.0",
-                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-                            "requires": {
-                                "hoek": "4.2.0"
-                            }
-                        }
-                    }
-                },
-                "form-data": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-                    "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.17"
-                    }
-                },
-                "har-validator": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-                    "requires": {
-                        "ajv": "5.5.1",
-                        "har-schema": "2.0.0"
-                    }
-                },
-                "hawk": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-                    "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.0",
-                        "sntp": "2.1.0"
-                    }
-                },
-                "hoek": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-                    "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-                },
-                "http-signature": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-                },
-                "sntp": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-                    "requires": {
-                        "hoek": "4.2.0"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
+                "extend": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
                 }
             }
         },
@@ -2546,10 +2055,10 @@
             "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.1.tgz",
             "integrity": "sha1-fuxWyJMXqCLL/qmbA5zlQ8LhX2c=",
             "requires": {
-                "bluebird": "3.5.1",
+                "bluebird": "^3.5.0",
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.0"
             }
         },
         "request-promise-core": {
@@ -2557,7 +2066,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.13.1"
             }
         },
         "requires-port": {
@@ -2572,7 +2081,7 @@
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "rimraf": {
@@ -2581,13 +2090,18 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
             "version": "0.5.8",
@@ -2604,14 +2118,6 @@
             "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
             "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
         },
-        "sntp": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "requires": {
-                "hoek": "2.16.3"
-            }
-        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2619,19 +2125,14 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-            "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+            "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
-        },
-        "sparkles": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-            "dev": true
         },
         "split": {
             "version": "0.3.3",
@@ -2639,29 +2140,23 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -2681,7 +2176,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -2696,7 +2191,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2706,18 +2201,9 @@
             "dev": true
         },
         "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
-        "stringstream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -2725,7 +2211,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -2734,7 +2220,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -2743,8 +2229,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "supports-color": {
@@ -2759,9 +2245,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -2775,8 +2261,40 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "through2-filter": {
@@ -2785,15 +2303,9 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
-        },
-        "time-stamp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-            "dev": true
         },
         "to-absolute-glob": {
             "version": "0.1.1",
@@ -2801,7 +2313,18 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "tough-cookie": {
@@ -2809,7 +2332,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tslib": {
@@ -2824,17 +2347,17 @@
             "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.3.0",
-                "commander": "2.12.2",
-                "diff": "3.3.1",
-                "glob": "7.1.2",
-                "minimatch": "3.0.4",
-                "resolve": "1.5.0",
-                "semver": "5.4.1",
-                "tslib": "1.8.1",
-                "tsutils": "2.16.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.1.0",
+                "commander": "^2.9.0",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.7.1",
+                "tsutils": "^2.12.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2843,7 +2366,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -2852,9 +2375,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "supports-color": {
@@ -2863,7 +2386,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -2874,7 +2397,7 @@
             "integrity": "sha512-9Ier/60O7OZRNPiw+or5QAtAY4kQA+WDiO/r6xOYATEyefH9bdfvTRLCxrYnFhQlZfET2vYXKfpr3Vw2BiArZw==",
             "dev": true,
             "requires": {
-                "tslib": "1.8.1"
+                "tslib": "^1.8.1"
             }
         },
         "tunnel": {
@@ -2883,10 +2406,12 @@
             "integrity": "sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA=="
         },
         "tunnel-agent": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-            "dev": true
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "tweetnacl": {
             "version": "0.14.5",
@@ -2911,8 +2436,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "universalify": {
@@ -2921,13 +2446,13 @@
             "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
         },
         "url-parse": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
-            "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -2947,36 +2472,28 @@
             "dev": true
         },
         "validator": {
-            "version": "3.35.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-3.35.0.tgz",
-            "integrity": "sha1-PwcklALB/I/Ak8MsbkPXKnnModw="
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+            "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
         },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -2985,29 +2502,35 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.1",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.3",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                "clone": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
                     "dev": true
                 },
                 "vinyl": {
@@ -3016,114 +2539,62 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
             }
         },
         "vinyl-source-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
-            "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
+            "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
-                    }
-                }
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vscode": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.10.tgz",
-            "integrity": "sha512-MvFXXSGuhw0Q6GC6dQrnRc0ES+63wpttGIoYGBMQnoS9JFCCNC/rWfX0lBCHJyuKL2Q8CYg0ROsMEHbHVwEtVw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.18.tgz",
+            "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.0.1",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.0.1",
-                "request": "2.83.0",
-                "semver": "5.4.1",
-                "source-map-support": "0.5.0",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.0"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.0.17",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.17.tgz",
-            "integrity": "sha512-FeoTciUInogaani+c2kkMqpcrf72SgZcugIFQ7szrkbzNxGwe8AiQlyVNAjbQr+22paungUJBo0LIAHeIfEAaA==",
+            "version": "0.0.18",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.18.tgz",
+            "integrity": "sha512-Vw3Sr+dZwl+c6PlsUwrTtCOJkgrmvS3OUVDQGcmpXWAgq9xGq6as0K4pUx+aGqTjzLAESmWSrs6HlJm6J6Khcg==",
             "requires": {
                 "applicationinsights": "1.0.1"
             }
         },
         "vscode-extension-telemetry-wrapper": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.2.2.tgz",
-            "integrity": "sha512-ok+QTVe66B0NdZHptGkKwpxU0t5r+N4WB4aSV2zRbsvJ5uUCVoZQ7/9L6egBddqSAPdXLOFrYsNCmnsV3X0UGQ==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.2.4.tgz",
+            "integrity": "sha512-gfWiadvqvQr6rIALBGg7sFB3fz7uc5tt0rJVkc6qe8Q6QLlCFQuhXESPOUR2nqfQcNjvKnDYg9bIm5MU7EHX4Q==",
             "requires": {
-                "continuation-local-storage": "3.2.1",
-                "fs-extra": "5.0.0",
-                "uuid": "3.1.0",
-                "vscode-extension-telemetry": "0.0.17"
+                "continuation-local-storage": "^3.2.1",
+                "fs-extra": "^5.0.0",
+                "uuid": "^3.1.0",
+                "vscode-extension-telemetry": "^0.0.18"
             },
             "dependencies": {
                 "fs-extra": {
@@ -3131,9 +2602,9 @@
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
                     "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 }
             }
@@ -3149,7 +2620,7 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
             "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
             "requires": {
-                "sax": "0.5.8"
+                "sax": "0.5.x"
             }
         },
         "xmlbuilder": {
@@ -3174,13 +2645,13 @@
             "dev": true
         },
         "yauzl": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
@@ -3189,7 +2660,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         },
         "zone.js": {

--- a/package.json
+++ b/package.json
@@ -147,18 +147,18 @@
         "@types/semver": "^5.4.0",
         "tslint": "^5.8.0",
         "typescript": "^2.6.1",
-        "vscode": "^1.1.6"
+        "vscode": "^1.1.18"
     },
     "dependencies": {
         "azure-arm-resource": "^2.0.0-preview",
-        "azure-storage": "^2.8.0",
+        "azure-storage": "^2.10.1",
         "fs-extra": "^4.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.10",
         "ms-rest": "^2.3.2",
-        "ms-rest-azure": "^2.5.5",
+        "ms-rest-azure": "^2.5.7",
         "opn": "5.1.0",
         "request-promise": "4.2.1",
-        "vscode-extension-telemetry-wrapper": "0.2.2"
+        "vscode-extension-telemetry-wrapper": "0.2.4"
     },
     "extensionDependencies": [
         "ms-vscode.azure-account"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureterraform",
     "displayName": "Azure Terraform",
     "description": "VS Code extension for developing with Terraform on Azure",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "ms-azuretools",
     "aiKey": "ae482601-060f-4c71-8567-ebd5085483c9",
     "icon": "images/terraform.png",


### PR DESCRIPTION
`vscode-extension-telemetry` should be at least `v0.0.17`.