### PR TITLE
Upgrade telemetry package to the latest compatible version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,9 +135,9 @@
             "dev": true
         },
         "applicationinsights": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz",
-            "integrity": "sha1-U0Rrgw/o1dYZ7uKieLMdPSUDCSc=",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.8.tgz",
+            "integrity": "sha512-KzOOGdphOS/lXWMFZe5440LUdFbrLpMvh2SaRxn7BmiI550KAoSb2gIhiq6kJZ9Ir3AxRRztjhzif+e5P5IXIg==",
             "requires": {
                 "diagnostic-channel": "0.2.0",
                 "diagnostic-channel-publishers": "0.2.1",
@@ -166,9 +166,9 @@
             }
         },
         "async-listener": {
-            "version": "0.6.9",
-            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz",
-            "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
             "requires": {
                 "semver": "^5.3.0",
                 "shimmer": "^1.1.0"
@@ -434,9 +434,9 @@
             }
         },
         "emitter-listener": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.1.tgz",
-            "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
             "requires": {
                 "shimmer": "^1.2.0"
             }
@@ -1069,9 +1069,9 @@
             "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         },
         "shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -1403,33 +1403,27 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.18.tgz",
-            "integrity": "sha512-Vw3Sr+dZwl+c6PlsUwrTtCOJkgrmvS3OUVDQGcmpXWAgq9xGq6as0K4pUx+aGqTjzLAESmWSrs6HlJm6J6Khcg==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.1.tgz",
+            "integrity": "sha512-TkKKG/B/J94DP5qf6xWB4YaqlhWDg6zbbqVx7Bz//stLQNnfE9XS1xm3f6fl24c5+bnEK0/wHgMgZYKIKxPeUA==",
             "requires": {
-                "applicationinsights": "1.0.1"
+                "applicationinsights": "1.0.8"
             }
         },
         "vscode-extension-telemetry-wrapper": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.2.4.tgz",
-            "integrity": "sha512-gfWiadvqvQr6rIALBGg7sFB3fz7uc5tt0rJVkc6qe8Q6QLlCFQuhXESPOUR2nqfQcNjvKnDYg9bIm5MU7EHX4Q==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.3.9.tgz",
+            "integrity": "sha512-zKm6lOroUdjI3JOIKP/m4bCrnQHHGemkLIB+DvYWobUd6etGEzqtcCmR+ZqVGII/fR6OB4oWAAwmflaaNpTOFg==",
             "requires": {
                 "continuation-local-storage": "^3.2.1",
-                "fs-extra": "^5.0.0",
-                "uuid": "^3.1.0",
-                "vscode-extension-telemetry": "^0.0.18"
+                "uuid": "^3.3.2",
+                "vscode-extension-telemetry": "^0.1.1"
             },
             "dependencies": {
-                "fs-extra": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "ms-rest-azure": "^2.5.7",
         "opn": "5.1.0",
         "request-promise": "4.2.1",
-        "vscode-extension-telemetry-wrapper": "0.2.4"
+        "vscode-extension-telemetry-wrapper": "^0.3.9"
     },
     "extensionDependencies": [
         "ms-vscode.azure-account"


### PR DESCRIPTION
This PR fixes #184 .

I did not upgrade it to the actual latest `0.4.0` because this version is not backward compatible. According to the author, he suggests me to upgrade to `0.3.9` instead.