### PR TITLE
enable npm run test for CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ language: node_js
 node_js:
   - 'stable'
 
+dist: xenial
+addons:
+  apt:
+    packages:
+      - libsecret-1-dev
+sudo: required
+services:
+  - xvfb
+
 before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
+  - export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
 
 install:
   - npm install -g vsce
@@ -16,7 +21,7 @@ install:
 
 script:
   - npm run lint
-  # - npm run test
+  - npm run test
   - vsce package
 
 notifications:


### PR DESCRIPTION
- enable npm run test for CI process in travis.yml 
- change the way of starting xvfb according to https://benlimmer.com/2019/01/14/travis-ci-xvfb, no need to support multi OS CI job

(fixes #139)