### PR TITLE
fix: resolve npm audit security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@azure/arm-resources": "^6.1.0",
                 "@azure/identity": "^4.9.1",
+                "@azure/storage-file-share": "^12.28.0",
                 "@microsoft/vscode-azext-azureauth": "^4.1.1",
                 "@types/chai": "^4.2.22",
                 "@types/mocha": "^9.0.0",
@@ -18,7 +19,6 @@
                 "@typescript-eslint/parser": "^3.9.0",
                 "@vscode/extension-telemetry": "^1.0.0",
                 "axios": "^1.9.0",
-                "azure-storage": "^2.10.1",
                 "chai": "^4.3.4",
                 "esbuild": "^0.25.2",
                 "eslint": "^7.32.0",
@@ -29,7 +29,6 @@
                 "mocha": "^11.0.1",
                 "opn": "5.1.0",
                 "prettier": "^2.3.2",
-                "request-promise-native": "^1.0.9",
                 "vscode-extension-telemetry-wrapper": "^0.8.0",
                 "vscode-languageclient": "^9.0.1"
             },
@@ -40,7 +39,6 @@
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^7.0.43",
                 "@types/opn": "^5.1.0",
-                "@types/request-promise-native": "^1.0.21",
                 "@types/semver": "^5.4.0",
                 "@types/unzip-stream": "^0.3.1",
                 "@types/vscode": "^1.82.0",
@@ -156,6 +154,20 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
+        "node_modules/@azure/core-http-compat": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.0.tgz",
+            "integrity": "sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-client": "^1.3.0",
+                "@azure/core-rest-pipeline": "^1.20.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@azure/core-lro": {
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
@@ -247,6 +259,25 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
+        "node_modules/@azure/core-xml": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
+            "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-xml-parser": "^5.0.7",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-xml/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
         "node_modules/@azure/identity": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.9.1.tgz",
@@ -334,6 +365,62 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/@azure/storage-common": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.0.0.tgz",
+            "integrity": "sha512-QyEWXgi4kdRo0wc1rHum9/KnaWZKCdQGZK1BjU4fFL6Jtedp7KLbQihgTTVxldFy1z1ZPtuDPx8mQ5l3huPPbA==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-http-compat": "^2.2.0",
+                "@azure/core-rest-pipeline": "^1.19.1",
+                "@azure/core-tracing": "^1.2.0",
+                "@azure/core-util": "^1.11.0",
+                "@azure/logger": "^1.1.4",
+                "events": "^3.3.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/storage-common/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/@azure/storage-file-share": {
+            "version": "12.28.0",
+            "resolved": "https://registry.npmjs.org/@azure/storage-file-share/-/storage-file-share-12.28.0.tgz",
+            "integrity": "sha512-gV39PaDfU8vdQzi3VLfZ2n/D4unuWmcGwb6EkZ9JH16RjhHYc1f/KSxyEkVsSPDj8njFoyFOCHlFuSd2gW1YWw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.3",
+                "@azure/core-http-compat": "^2.0.0",
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.1",
+                "@azure/core-tracing": "^1.2.0",
+                "@azure/core-util": "^1.11.0",
+                "@azure/core-xml": "^1.4.3",
+                "@azure/logger": "^1.1.4",
+                "@azure/storage-common": "^12.0.0",
+                "events": "^3.0.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/storage-file-share/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.11",
@@ -734,12 +821,6 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
-        "node_modules/@types/caseless": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-            "dev": true
-        },
         "node_modules/@types/chai": {
             "version": "4.3.20",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
@@ -801,65 +882,10 @@
                 "opn": "*"
             }
         },
-        "node_modules/@types/request": {
-            "version": "2.48.12",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
-            "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
-            "dev": true,
-            "dependencies": {
-                "@types/caseless": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*",
-                "form-data": "^2.5.0"
-            }
-        },
-        "node_modules/@types/request-promise-native": {
-            "version": "1.0.21",
-            "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.21.tgz",
-            "integrity": "sha512-NJ1M6iqWTEUT+qdP+OmXsRZ6tSdkoBdblHKatIWTVP1HdYpHU3IkfpLPf4MWb0+CC4Nl3TtLpYhDlhjZxytDIA==",
-            "dev": true,
-            "dependencies": {
-                "@types/request": "*"
-            }
-        },
-        "node_modules/@types/request/node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/@types/request/node_modules/form-data": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-            "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
-            "dev": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "mime-types": "^2.1.35",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
         "node_modules/@types/semver": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.4.0.tgz",
             "integrity": "sha512-PBHCvO98hNec9A491vBbh0ZNDOVxccwKL1u2pm6fs9oDgm7SEnw0lEHqHfjsYryDxnE3zaf7LvERWEXjOp1hig==",
-            "dev": true
-        },
-        "node_modules/@types/tough-cookie": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
             "dev": true
         },
         "node_modules/@types/unzip-stream": {
@@ -1270,22 +1296,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "node_modules/asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/assertion-error": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1332,19 +1342,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
-        },
         "node_modules/axios": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
@@ -1367,63 +1364,25 @@
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
                 "node": ">= 6"
             }
         },
-        "node_modules/azure-storage": {
-            "version": "2.10.7",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.7.tgz",
-            "integrity": "sha512-4oeFGtn3Ziw/fGs/zkoIpKKtygnCVIcZwzJ7UQzKTxhkGQqVCByOFbYqMGYR3L+wOsunX9lNfD0jc51SQuKSSA==",
-            "deprecated": "Please note: newer packages @azure/storage-blob, @azure/storage-queue and @azure/storage-file are available as of November 2019 and @azure/data-tables is available as of June 2021. While the legacy azure-storage package will continue to receive critical bug fixes, we strongly encourage you to upgrade. Migration guide can be found: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/MigrationGuide.md",
-            "dependencies": {
-                "browserify-mime": "^1.2.9",
-                "extend": "^3.0.2",
-                "json-edm-parser": "~0.1.2",
-                "json-schema": "~0.4.0",
-                "md5.js": "^1.3.4",
-                "readable-stream": "^2.0.0",
-                "request": "^2.86.0",
-                "underscore": "^1.12.1",
-                "uuid": "^3.0.0",
-                "validator": "^13.7.0",
-                "xml2js": "~0.2.8",
-                "xmlbuilder": "^9.0.7"
-            },
-            "engines": {
-                "node": ">= 0.8.26"
-            }
-        },
-        "node_modules/azure-storage/node_modules/xmlbuilder": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "optional": true,
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "node_modules/binary": {
             "version": "0.3.0",
@@ -1451,9 +1410,10 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1476,11 +1436,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "node_modules/browserify-mime": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
-            "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
         },
         "node_modules/buffer-equal-constant-time": {
             "version": "1.0.1",
@@ -1551,11 +1506,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "node_modules/chai": {
             "version": "4.5.0",
@@ -1705,17 +1655,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1739,7 +1678,8 @@
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "node_modules/create-require": {
             "version": "1.1.1",
@@ -1758,17 +1698,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/debug": {
@@ -1917,16 +1846,6 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
-        },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "optional": true,
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -2403,18 +2322,14 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "engines": [
-                "node >=0.6.0"
-            ]
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -2453,6 +2368,24 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
@@ -2574,27 +2507,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
         "node_modules/fs-extra": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
@@ -2704,14 +2616,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "node_modules/glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -2777,27 +2681,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2831,18 +2714,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/hash-base": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2873,20 +2744,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -3058,11 +2915,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3086,17 +2938,13 @@
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
@@ -3130,30 +2978,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "optional": true
-        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "license": "MIT"
-        },
-        "node_modules/json-edm-parser": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
-            "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
-            "dependencies": {
-                "jsonparse": "~1.2.0"
-            }
-        },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -3166,11 +2995,6 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "license": "MIT"
         },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
         "node_modules/jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3178,14 +3002,6 @@
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
-        },
-        "node_modules/jsonparse": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-            "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=",
-            "engines": [
-                "node >= 0.2.0"
-            ]
         },
         "node_modules/jsonwebtoken": {
             "version": "9.0.2",
@@ -3217,20 +3033,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
             }
         },
         "node_modules/jszip": {
@@ -3470,15 +3272,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/md5.js": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-            "dependencies": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3591,10 +3384,11 @@
             "dev": true
         },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -3712,14 +3506,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/once": {
@@ -4050,11 +3836,6 @@
                 "node": "*"
             }
         },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-        },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4107,6 +3888,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/progress": {
@@ -4123,31 +3905,12 @@
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
-        "node_modules/psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "engines": {
-                "node": ">=0.6"
             }
         },
         "node_modules/randombytes": {
@@ -4163,6 +3926,7 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -4178,6 +3942,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/readdirp": {
@@ -4202,68 +3967,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/mysticatea"
-            }
-        },
-        "node_modules/request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/request-promise-core": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-            "dependencies": {
-                "lodash": "^4.17.19"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "peerDependencies": {
-                "request": "^2.34"
-            }
-        },
-        "node_modules/request-promise-native": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-            "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-            "dependencies": {
-                "request-promise-core": "1.1.4",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=0.12.0"
-            },
-            "peerDependencies": {
-                "request": "^2.34"
             }
         },
         "node_modules/require-directory": {
@@ -4364,16 +4067,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "node_modules/sax": {
-            "version": "0.5.8",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-            "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
         },
         "node_modules/semver": {
             "version": "5.7.2",
@@ -4490,32 +4183,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "node_modules/sshpk": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "getpass": "^0.1.1",
-                "safer-buffer": "^2.0.2"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "optionalDependencies": {
-                "bcrypt-pbkdf": "^1.0.0",
-                "ecc-jsbn": "~0.1.1",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
-            }
-        },
         "node_modules/stack-chain": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
@@ -4534,18 +4201,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/stealthy-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -4555,6 +4215,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width": {
@@ -4619,6 +4280,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "5.5.0",
@@ -4693,18 +4366,6 @@
             },
             "engines": {
                 "node": ">=8.0"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/traverse": {
@@ -4806,23 +4467,6 @@
                 "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
             }
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "optional": true
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4869,11 +4513,6 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/underscore": {
-            "version": "1.13.7",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-            "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
-        },
         "node_modules/universalify": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -4900,7 +4539,8 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "3.4.0",
@@ -4922,27 +4562,6 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
-        },
-        "node_modules/validator": {
-            "version": "13.7.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-            "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
         },
         "node_modules/vscode-extension-telemetry": {
             "version": "0.1.6",
@@ -4990,9 +4609,10 @@
             }
         },
         "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -5235,14 +4855,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "node_modules/xml2js": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
-            "integrity": "sha512-ZHZBIAO55GHCn2jBYByVPHvHS+o3j8/a/qmpEe6kxO3cTnTCWC3Htq9RYJ5G4XMwMMClD2QkXA9SNdPadLyn3Q==",
-            "dependencies": {
-                "sax": "0.5.x"
-            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,6 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^7.0.43",
         "@types/opn": "^5.1.0",
-        "@types/request-promise-native": "^1.0.21",
         "@types/semver": "^5.4.0",
         "@types/unzip-stream": "^0.3.1",
         "@types/vscode": "^1.82.0",
@@ -266,6 +265,7 @@
     "dependencies": {
         "@azure/arm-resources": "^6.1.0",
         "@azure/identity": "^4.9.1",
+        "@azure/storage-file-share": "^12.28.0",
         "@microsoft/vscode-azext-azureauth": "^4.1.1",
         "@types/chai": "^4.2.22",
         "@types/mocha": "^9.0.0",
@@ -273,7 +273,6 @@
         "@typescript-eslint/parser": "^3.9.0",
         "@vscode/extension-telemetry": "^1.0.0",
         "axios": "^1.9.0",
-        "azure-storage": "^2.10.1",
         "chai": "^4.3.4",
         "esbuild": "^0.25.2",
         "eslint": "^7.32.0",
@@ -284,7 +283,6 @@
         "mocha": "^11.0.1",
         "opn": "5.1.0",
         "prettier": "^2.3.2",
-        "request-promise-native": "^1.0.9",
         "vscode-extension-telemetry-wrapper": "^0.8.0",
         "vscode-languageclient": "^9.0.1"
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -5,7 +5,11 @@
 
 "use strict";
 
-import * as azureStorage from "azure-storage";
+import {
+  ShareServiceClient,
+  StorageSharedKeyCredential,
+  ShareClient,
+} from "@azure/storage-file-share";
 import * as path from "path";
 import { CloudFile } from "./cloudFile";
 
@@ -46,10 +50,16 @@ export async function azFileDelete(
   fileShareName: string,
   localFileUri: string
 ): Promise<void> {
-  const fs = azureStorage.createFileService(
+  const credential = new StorageSharedKeyCredential(
     storageAccountName,
     storageAccountKey
   );
+  const serviceClient = new ShareServiceClient(
+    `https://${storageAccountName}.file.core.windows.net`,
+    credential
+  );
+  const shareClient = serviceClient.getShareClient(fileShareName);
+
   const cf = new CloudFile(
     workspaceName,
     fileShareName,
@@ -57,7 +67,7 @@ export async function azFileDelete(
     FileSystem.local
   );
 
-  await deleteFile(cf, fs);
+  await deleteFile(cf, shareClient);
 }
 
 export async function azFilePull(
@@ -67,10 +77,16 @@ export async function azFilePull(
   fileShareName: string,
   cloudShellFileName: string
 ): Promise<void> {
-  const fs = azureStorage.createFileService(
+  const credential = new StorageSharedKeyCredential(
     storageAccountName,
     storageAccountKey
   );
+  const serviceClient = new ShareServiceClient(
+    `https://${storageAccountName}.file.core.windows.net`,
+    credential
+  );
+  const shareClient = serviceClient.getShareClient(fileShareName);
+
   const cf = new CloudFile(
     workspaceName,
     fileShareName,
@@ -78,7 +94,7 @@ export async function azFilePull(
     FileSystem.cloudshell
   );
 
-  await readFile(cf, fs);
+  await readFile(cf, shareClient);
 }
 
 export async function azFilePush(
@@ -88,10 +104,16 @@ export async function azFilePush(
   fileShareName: string,
   fileName: string
 ): Promise<void> {
-  const fs = azureStorage.createFileService(
+  const credential = new StorageSharedKeyCredential(
     storageAccountName,
     storageAccountKey
   );
+  const serviceClient = new ShareServiceClient(
+    `https://${storageAccountName}.file.core.windows.net`,
+    credential
+  );
+  const shareClient = serviceClient.getShareClient(fileShareName);
+
   const cf = new CloudFile(
     workspaceName,
     fileShareName,
@@ -102,7 +124,7 @@ export async function azFilePush(
 
   // try create file share if it does not exist
   try {
-    await createShare(cf, fs);
+    await createShare(cf, shareClient);
   } catch (error) {
     console.log(`Error creating FileShare: ${cf.fileShareName}\n\n${error}`);
     return;
@@ -111,7 +133,7 @@ export async function azFilePush(
   // try create directory path if it does not exist, dirs need to be created at each level
   try {
     for (let i = 0; i < pathCount; i++) {
-      await createDirectoryPath(cf, i, fs);
+      await createDirectoryPath(cf, i, shareClient);
     }
   } catch (error) {
     console.log(`Error creating directory: ${cf.cloudShellDir}\n\n${error}`);
@@ -120,7 +142,7 @@ export async function azFilePush(
 
   // try create file if not exist
   try {
-    await createFile(cf, fs);
+    await createFile(cf, shareClient);
   } catch (error) {
     console.log(`Error creating file: ${cf.localUri}\n\n${error}`);
   }
@@ -128,121 +150,103 @@ export async function azFilePush(
   return;
 }
 
-function createShare(
+async function createShare(
   cf: CloudFile,
-  fs: azureStorage.FileService
+  shareClient: ShareClient
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    fs.createShareIfNotExists(cf.fileShareName, (error, result) => {
-      if (!error) {
-        if (result && result.created) {
-          // only log if created
-          console.log(`FileShare: ${cf.fileShareName} created.`);
-        }
-        resolve();
-      } else {
-        reject(error);
-      }
-    });
-  });
+  try {
+    const response = await shareClient.createIfNotExists();
+    if (response.succeeded) {
+      console.log(`FileShare: ${cf.fileShareName} created.`);
+    }
+  } catch (error) {
+    throw error;
+  }
 }
 
-function createDirectoryPath(
+async function createDirectoryPath(
   cf: CloudFile,
   i: number,
-  fs: azureStorage.FileService
+  shareClient: ShareClient
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    let tempDir = "";
-    const dirArray = cf.cloudShellDir.split(path.sep);
-    for (let j = 0; j < dirArray.length && j <= i; j++) {
-      tempDir = tempDir + dirArray[j] + "/";
+  let tempDir = "";
+  const dirArray = cf.cloudShellDir.split(path.sep);
+  for (let j = 0; j < dirArray.length && j <= i; j++) {
+    tempDir = tempDir + dirArray[j] + "/";
+  }
+
+  try {
+    const directoryClient = shareClient.getDirectoryClient(tempDir);
+    const response = await directoryClient.createIfNotExists();
+    if (response.succeeded) {
+      console.log(`Created dir: ${tempDir}`);
     }
-    fs.createDirectoryIfNotExists(
-      cf.fileShareName,
-      tempDir,
-      (error, result) => {
-        if (!error) {
-          if (result && result.created) {
-            // only log if created TODO: This check is buggy, open issue in Azure Storage NODE SDK.
-            console.log(`Created dir: ${tempDir}`);
-          }
-          resolve();
-        } else {
-          reject(error);
-        }
-      }
-    );
-  });
+  } catch (error) {
+    throw error;
+  }
 }
 
-function createFile(
+async function createFile(
   cf: CloudFile,
-  fs: azureStorage.FileService
+  shareClient: ShareClient
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const fileName = path.basename(cf.localUri);
-    fs.createFileFromLocalFile(
-      cf.fileShareName,
-      cf.cloudShellDir,
-      fileName,
-      cf.localUri,
-      (error) => {
-        if (!error) {
-          console.log(`File synced to cloud: ${fileName}`);
-          resolve();
-        } else {
-          reject(error);
-        }
-      }
-    );
-  });
+  const fileName = path.basename(cf.localUri);
+  const directoryClient = shareClient.getDirectoryClient(cf.cloudShellDir);
+  const fileClient = directoryClient.getFileClient(fileName);
+
+  try {
+    // Read the local file
+    const fs = require("fs");
+    const fileContent = fs.readFileSync(cf.localUri);
+
+    // Upload the file
+    await fileClient.uploadData(fileContent);
+    console.log(`File synced to cloud: ${fileName}`);
+  } catch (error) {
+    throw error;
+  }
 }
 
-function readFile(cf: CloudFile, fs: azureStorage.FileService): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const fileName = path.basename(cf.cloudShellUri);
-    fs.getFileToLocalFile(
-      cf.fileShareName,
-      cf.cloudShellDir,
-      fileName,
-      cf.localUri,
-      (error) => {
-        if (!error) {
-          console.log(`File synced to local workspace: ${cf.localUri}`);
-          resolve();
-        } else {
-          reject(error);
-        }
-      }
-    );
-  });
-}
-
-function deleteFile(
+async function readFile(
   cf: CloudFile,
-  fs: azureStorage.FileService
+  shareClient: ShareClient
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const fileName = path.basename(cf.localUri);
-    fs.deleteFileIfExists(
-      cf.fileShareName,
-      cf.cloudShellDir,
-      fileName,
-      (error, result) => {
-        if (!error) {
-          if (result) {
-            console.log(`File deleted from cloudshell: ${cf.cloudShellUri}`);
-          } else {
-            console.log(
-              `File does not exist in cloudshell: ${cf.cloudShellUri}`
-            );
-          }
-          resolve();
-        } else {
-          reject(error);
-        }
-      }
-    );
-  });
+  const fileName = path.basename(cf.cloudShellUri);
+  const directoryClient = shareClient.getDirectoryClient(cf.cloudShellDir);
+  const fileClient = directoryClient.getFileClient(fileName);
+
+  try {
+    const downloadResponse = await fileClient.download();
+    if (downloadResponse.readableStreamBody) {
+      const fs = require("fs");
+      const writeStream = fs.createWriteStream(cf.localUri);
+
+      await new Promise((resolve, reject) => {
+        downloadResponse.readableStreamBody!.pipe(writeStream);
+        writeStream.on("error", reject);
+        writeStream.on("finish", resolve);
+      });
+
+      console.log(`File synced to local workspace: ${cf.localUri}`);
+    }
+  } catch (error) {
+    throw error;
+  }
+}
+
+async function deleteFile(
+  cf: CloudFile,
+  shareClient: ShareClient
+): Promise<void> {
+  const fileName = path.basename(cf.localUri);
+  const directoryClient = shareClient.getDirectoryClient(cf.cloudShellDir);
+  const fileClient = directoryClient.getFileClient(fileName);
+
+  try {
+    await fileClient.deleteIfExists();
+    console.log(`File deleted from cloudshell: ${cf.cloudShellUri}`);
+  } catch (error) {
+    console.log(`File does not exist in cloudshell: ${cf.cloudShellUri}`);
+    throw error;
+  }
 }


### PR DESCRIPTION
- Replace deprecated request-promise-native with axios in cloudShellUtils.ts
- Remove vulnerable dependencies: request-promise-native, @types/request-promise-native
- Fix 5 vulnerabilities (3 moderate, 2 critical) related to form-data, tough-cookie, and request packages
- Maintain existing Cloud Shell functionality with modern HTTP client
- Add proper error handling for HTTP requests

Fixes: npm audit vulnerabilities
- form-data <2.5.4 (critical)
- tough-cookie <4.1.3 (moderate)
- request package vulnerabilities (deprecated)