### PR TITLE
fix: skip .zip files when finding extracted preflight binary

### DIFF
--- a/src/build/preflightDownloader.ts
+++ b/src/build/preflightDownloader.ts
@@ -122,6 +122,7 @@ async function run(platform: string, architecture: string) {
         let candidate: string | undefined;
         const files = fs.readdirSync(installPath);
         for (const f of files) {
+          if (f.endsWith(".zip")) continue;
           const startsWithVersion = f.indexOf("aztfpreflight_v") === 0;
           const extOk = fileExtension ? f.endsWith(fileExtension) : true;
           if (startsWithVersion && extOk) {


### PR DESCRIPTION
On Linux/macOS, the zip file itself (e.g. aztfpreflight_v0.4.0.zip) matched the 'aztfpreflight_v' prefix pattern because fileExtension is empty and extOk was unconditionally true. This caused the zip to be renamed to the binary name, and the subsequent unlinkSync on the original zip path failed with ENOENT.

Adding a check to skip .zip files during candidate scanning fixes the issue.