### PR TITLE
fix: align engines.vscode and @types/vscode to ^1.90.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # @types/vscode must stay in sync with engines.vscode in package.json.
+      # Bumping it forces a minimum VS Code version upgrade for all users, so
+      # we manage it manually rather than letting dependabot auto-update it.
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.82.0"
+    "vscode": "^1.90.0"
   },
   "preview": true,
   "categories": [
@@ -264,7 +264,7 @@
     "@types/opn": "^5.1.0",
     "@types/semver": "^5.5.0",
     "@types/unzip-stream": "^0.3.1",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.90.0",
     "@vscode/test-electron": "^2.4.1",
     "diff": ">=4.0.4",
     "mocha": "^11.7.5",


### PR DESCRIPTION
Bump engines.vscode from ^1.82.0 to ^1.90.0 and downgrade @types/vscode from ^1.120.0 to ^1.90.0 to fix the vsce package version mismatch error.

Configure dependabot to ignore minor/patch updates for @types/vscode so the VS Code minimum version requirement is not bumped automatically.