### PR TITLE
ci: guard against package-lock.json drift in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: npm install
         run: npm install
+      - name: Check package-lock.json is up to date
+        run: git diff --exit-code package-lock.json
       - name: lint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/opn": "^5.1.0",
         "@types/semver": "^5.5.0",
         "@types/unzip-stream": "^0.3.1",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "^1.90.0",
         "@vscode/test-electron": "^2.4.1",
         "diff": ">=4.0.4",
         "mocha": "^11.7.5",
@@ -53,7 +53,7 @@
         "vscode-test": "^1.6.1"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.90.0"
       }
     },
     "node_modules/@azure/abort-controller": {


### PR DESCRIPTION
## Problem
The lint job in CI used `npm install`, which silently updates
`package-lock.json` without failing. This meant PRs that modified
`package.json` without committing the corresponding lockfile changes
would still pass CI.

## Changes
- Added a `git diff --exit-code package-lock.json` check after `npm install`
  in the lint job. CI will now fail if the committed lockfile is out of sync
  with `package.json`.
- Updated `package-lock.json` to reflect the `@types/vscode` downgrade from
  `^1.120.0` to `^1.90.0` (committed separately in #<prev-PR>).