### PR TITLE
Change `azureTerraform.aztfpreflight.pathToBinary` vscode setting scope from `resource` to `machine`, CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,87 +1,119 @@
 # Change Log
 
-All notable changes to the "Microsoft Terraform" extension will be documented in this file.		
-		
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+All notable changes to the "Microsoft Terraform" extension will be
+documented in this file.
 
-## [0.9.0]
-### Changed
-- Updated ms-terraform-lsp to v0.9.0
-- Migrate to ESLint v9 flat config. ([#304](https://github.com/Azure/vscode-azureterraform/pull/304))
-- Updated dependencies:
+Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on
+how to structure this file.
+
+## [0.9.1]
+
+### Changed for 0.9.1
+
+- Updated package dependencies:
   - `@azure/identity`: `^4.9.1` → `^4.13.1`
   - `@azure/storage-file-share`: `^12.28.0` → `^12.30.0`
   - `@microsoft/vscode-azext-azureauth`: `^4.1.1` → `^4.2.2`
-  - `@typescript-eslint/eslint-plugin`: `^3.9.0` → `^8.59.3`
-  - `@typescript-eslint/parser`: `^3.9.0` → `^8.59.3`
+  - `@typescript-eslint/eslint-plugin`: `^8.56.1` → `^8.60.0`
+  - `@typescript-eslint/parser`: `^8.56.1` → `^8.60.0`
   - `@vscode/extension-telemetry`: `^1.0.0` → `^1.5.2`
-  - `axios`: `^1.12.0` → `^1.16.1`
+  - `axios`: `^1.13.5` → `^1.16.1`
   - `esbuild`: `^0.25.2` → `^0.28.0`
-  - `eslint`: `^7.32.0` → `^10.3.0`
-  - `eslint-config-prettier`: `^8.3.0` → `^10.1.8`
-  - `eslint-plugin-prettier`: `^3.4.1` → `^5.5.5`
-  - `lodash`: `^4.17.21` → `^4.18.1`
-  - `mocha`: `^11.0.1` → `^11.7.5`
+  - `eslint`: `^10.0.2` → `^10.4.0`
+  - `lodash`: `^4.17.23` → `^4.18.1`
+  - `mocha`: `^11.0.1` → `^11.7.6`
   - `opn`: `5.1.0` → `5.5.0`
-  - `prettier`: `^2.3.2` → `^3.8.3`
-  - `typescript-eslint`: added `^8.59.3`
+  - `prettier`: `^3.8.1` → `^3.8.3`
+  - `typescript-eslint`: `^8.56.1` → `^8.60.0`
   - `vscode-extension-telemetry-wrapper`: `^0.8.0` → `^0.15.3`
 
+## [0.9.0]
+
+### Changed for 0.9.0
+
+- Updated ms-terraform-lsp to v0.9.0
+- Migrate to ESLint v9 flat config. ([#304](https://github.com/Azure/vscode-azureterraform/pull/304))
 
 ## [0.8.0]
-### Added
+
+### Added for 0.8.0
+
 - Update ms-terraform-lsp to v0.8.0
 - Update survey link.
 
 ## [0.7.0]
-### Added
-- Support for Terraform preflight validation command. Preflight validation runs against generated Terraform plans to identify potential issues before deployment
+
+### Added for 0.7.0
+
+- Support for Terraform preflight validation command. Preflight validation
+  runs against generated Terraform plans to identify potential issues before
+  deployment
 - Integrated `aztfpreflight` binary download and execution
 
 ## [0.6.0]
-### Added
+
+### Added for 0.6.0
+
 - Support auto-completion and hover documentation for Azure Verified Modules.
 - Add auto-completion and hover documentation for data sources.
 
 ## [0.5.0]
-### Added
-- Suggest azapi provider resources, properties, and values for those properties
+
+### Added for 0.5.0
+
+- Suggest azapi provider resources, properties, and values for those
+  properties
 - On-hover documentation for azapi resources and properties
 - Code actions to migrate resources between azurerm and azapi providers
 - Copy ARM Template/Resource JSON and paste it as azapi configuration
 
 ## [0.4.0]
-### Added
-- Suggest azurerm provider resources, properties, and values for those properties
+
+### Added for 0.4.0
+
+- Suggest azurerm provider resources, properties, and values for those
+  properties
 - On-hover documentation for fields
 - Suggestion and on-hover features for msgraph provider
-- Integration with Azure Export for Terraform to export Azure resources as Terraform blocks
+- Integration with Azure Export for Terraform to export Azure resources as
+  Terraform blocks
 - Integrated survey for user feedback
-- Support for code actions to generate required/missing permissions for `azurerm` providers
+- Support for code actions to generate required/missing permissions for
+  `azurerm` providers
 
-### Fixed
+### Fixed for 0.4.0
+
 - General improvements and bug fixes
 
 ## [0.3.3]
-### Changed
+
+### Changed for 0.3.3
+
 - Removed Azure Account extension dependency
   - [#254](https://github.com/Azure/vscode-azureterraform/pull/254)
 - CloudShell functionality is temporarily unavailable
-- Default terminal setting now falls back to integrated terminal when CloudShell is selected
+- Default terminal setting now falls back to integrated terminal when
+  CloudShell is selected
 
 ## [0.3.2]
-### Fixed
+
+### Fixed for 0.3.2
+
 - fix dependency issues
   - [#212](https://github.com/Azure/vscode-azureterraform/issues/212)
   - [#222](https://github.com/Azure/vscode-azureterraform/issues/222)
 
 ## [0.3.1]
-### Fixed
+
+### Fixed for 0.3.1
+
 - fix some security issues
   - [#220](https://github.com/Azure/vscode-azureterraform/pull/220)
 
 ## [0.3.0]
-### Fixed
+
+### Fixed for 0.3.0
+
 - fix some bugs and improve user experience
   - [#139](https://github.com/Azure/vscode-azureterraform/issues/139)
   - [#179](https://github.com/Azure/vscode-azureterraform/issues/179)
@@ -89,20 +121,34 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   - [#203](https://github.com/Azure/vscode-azureterraform/issues/203)
 
 ## [0.2.0]
-### Added
-- Support linting and end to end test for terraform module. ([#166](https://github.com/Azure/vscode-azureterraform/issues/166))
 
-### Changed
-- Combine push command with init, plan, apply and validate. ([#148](https://github.com/Azure/vscode-azureterraform/issues/148))
+### Added for 0.2.0
+
+- Support linting and end to end test for terraform module.
+  ([#166](https://github.com/Azure/vscode-azureterraform/issues/166))
+
+### Changed for 0.2.0
+
+- Combine push command with init, plan, apply and validate.
+  ([#148](https://github.com/Azure/vscode-azureterraform/issues/148))
 
 ## [0.1.1]
-### Changed
-- Leverage Azure Account extension to provision Cloud Shell. ([#145](https://github.com/Azure/vscode-azureterraform/issues/145))
 
-### Fixed
-- Fix the Cloud Shell cannot be connected error if last session is closed because of socket timeout. ([#144](https://github.com/Azure/vscode-azureterraform/issues/144))
+### Changed for 0.1.1
+
+- Leverage Azure Account extension to provision Cloud Shell.
+  ([#145](https://github.com/Azure/vscode-azureterraform/issues/145))
+
+### Fixed for 0.1.1
+
+- Fix the Cloud Shell cannot be connected error if last session is closed
+  because of socket timeout.
+  ([#144](https://github.com/Azure/vscode-azureterraform/issues/144))
 
 ## [0.1.0]
-### Added
-- Support Terraform commands: init, plan, apply, validate, refresh and destroy.
+
+### Added for 0.1.0
+
+- Support Terraform commands: init, plan, apply, validate, refresh and
+  destroy.
 - Support visualizing the terraform module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ documented in this file.
 Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on
 how to structure this file.
 
-## [0.9.1]
+## [0.10.0]
 
-### Changed for 0.9.1
+### Changed for 0.10.0
 
+- Changed `azureTerraform.aztfpreflight.pathToBinary` from `resource` to `machine` scope.
 - Updated package dependencies:
   - `@azure/identity`: `^4.9.1` → `^4.13.1`
   - `@azure/storage-file-share`: `^12.28.0` → `^12.30.0`
@@ -32,7 +33,12 @@ how to structure this file.
 ### Changed for 0.9.0
 
 - Updated ms-terraform-lsp to v0.9.0
-- Migrate to ESLint v9 flat config. ([#304](https://github.com/Azure/vscode-azureterraform/pull/304))
+- Migrated to ESLint v9 flat config. ([#304](https://github.com/Azure/vscode-azureterraform/pull/304))
+- Refreshed several dependencies, including `axios`, `lodash`, `fast-xml-parser`, `flatted`, `js-yaml`, `jws`, and `minimatch`.
+
+### Fixed for 0.9.0
+
+- Skipped `.zip` files when locating the extracted `aztfpreflight` binary on Linux and macOS, preventing the downloader from renaming the archive by mistake. ([#309](https://github.com/Azure/vscode-azureterraform/pull/309))
 
 ## [0.8.0]
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "title": "Microsoft Terraform",
       "properties": {
         "azureTerraform.aztfpreflight.pathToBinary": {
-          "scope": "resource",
+          "scope": "machine",
           "type": "string",
           "default": "",
           "description": "Path to aztfpreflight executable (optional). If empty, 'aztfpreflight' will be resolved from PATH."


### PR DESCRIPTION
This PR updates `azureTerraform.aztfpreflight.pathToBinary` vscode setting scope from `resource` to `machine` so that it cannot be overridden at repo/workspace level for malicious purposes.

Also alongside this is a bunch of CHANGELOG update in preparation of 0.10.0 release and to fix markdownlint violations.