### PR TITLE
Skip survey prompt when running under test mode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,15 @@ import { config } from "./vscodeUtils";
 import { TelemetryReporter } from "@vscode/extension-telemetry";
 import { terraformChannel } from "./terraformChannel";
 import { generateTerraformPlan } from "./utils/terraformPlan";
+import { ConvertJsonToAzapiResult, LanguageServerSettings } from "./types";
 import * as path from "path";
+
+const defaultLanguageServerSettings: LanguageServerSettings = {
+  external: true,
+  pathToBinary: "",
+  args: ["serve"],
+  "trace.server": "off",
+};
 
 let fileWatcher: vscode.FileSystemWatcher;
 
@@ -492,8 +500,12 @@ export async function activate(ctx: vscode.ExtensionContext) {
       "azureTerraform.enableLanguageServer",
       async () => {
         if (!enabled()) {
-          const currentConfig: any =
-            config("azureTerraform").get("languageServer");
+          const currentConfig = config(
+            "azureTerraform",
+          ).get<LanguageServerSettings>(
+            "languageServer",
+            defaultLanguageServerSettings,
+          );
           currentConfig.external = true;
           await config("azureTerraform").update(
             "languageServer",
@@ -511,8 +523,12 @@ export async function activate(ctx: vscode.ExtensionContext) {
       "azureTerraform.disableLanguageServer",
       async () => {
         if (enabled()) {
-          const currentConfig: any =
-            config("azureTerraform").get("languageServer");
+          const currentConfig = config(
+            "azureTerraform",
+          ).get<LanguageServerSettings>(
+            "languageServer",
+            defaultLanguageServerSettings,
+          );
           currentConfig.external = false;
           await config("azureTerraform").update(
             "languageServer",
@@ -579,13 +595,14 @@ export async function activate(ctx: vscode.ExtensionContext) {
           }
 
           try {
-            const result: any = await lsClient.client.sendRequest(
-              "workspace/executeCommand",
-              {
-                command: "ms-terraform.convertJsonToAzapi",
-                arguments: [`jsonContent=${clipboardText}`],
-              },
-            );
+            const result =
+              await lsClient.client.sendRequest<ConvertJsonToAzapiResult>(
+                "workspace/executeCommand",
+                {
+                  command: "ms-terraform.convertJsonToAzapi",
+                  arguments: [`jsonContent=${clipboardText}`],
+                },
+              );
 
             await editor.edit((editBuilder) => {
               const startPoint = contentChange.range.start;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -607,7 +607,10 @@ export async function activate(ctx: vscode.ExtensionContext) {
     startLanguageServer();
   }
 
-  if (await ShouldShowSurvey()) {
+  if (
+    ctx.extensionMode !== vscode.ExtensionMode.Test &&
+    (await ShouldShowSurvey())
+  ) {
     await ShowSurvey();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,3 +6,22 @@ export interface ExperimentalClientCapabilities {
     telemetryVersion?: number;
   };
 }
+
+/**
+ * Settings for the bundled language server, mirroring the
+ * `azureTerraform.languageServer` configuration contribution in package.json.
+ */
+export interface LanguageServerSettings {
+  external: boolean;
+  pathToBinary: string;
+  args: string[];
+  "trace.server": "off" | "messages" | "verbose";
+}
+
+/**
+ * Result returned by the language server's `ms-terraform.convertJsonToAzapi`
+ * command.
+ */
+export interface ConvertJsonToAzapiResult {
+  hclcontent: string;
+}


### PR DESCRIPTION
## Problem

`npm test` hangs indefinitely (the Extension Development Host sits at the welcome screen and never runs any test), eventually failing with `TestRunFailedError: Test run failed with code 1`.

The hang is **not** in the test runner, glob, or language server — the mocha suite is never even invoked.

## Root cause

`activate()` in `src/extension.ts` ends with:

```ts
if (await ShouldShowSurvey()) {
  await ShowSurvey();
}
```

`ShowSurvey()` (`src/survey.ts`) does:

```ts
const selected = await vscode.window.showInformationMessage(reloadMsg, "Yes", "Not Now", "Never");
```

That notification only resolves when a user clicks a button. Under automated (headless, `--disable-extensions`) test runs nobody clicks, so the promise never resolves → `activate()` never completes. `@vscode/test-electron` waits for activation to finish before calling the mocha runner's `run()`, so the tests never start.

The survey fires once `surveyPromptDate` is in the past (`ShouldShowSurvey()` returns `true`), which is why this surfaced now — the stored prompt date had elapsed.

## Fix

Skip the survey when running in test mode:

```ts
if (
  ctx.extensionMode !== vscode.ExtensionMode.Test &&
  (await ShouldShowSurvey())
) {
  await ShowSurvey();
}
```

Normal (non-test) behavior is unchanged.

## Verification

With the original elapsed `surveyPromptDate` in the test profile (the exact condition that caused the hang), `npm test` now completes:

```
✔ templates completion (18288ms)
1 passing (18s)
Exit code: 0
```