### PR TITLE
Bump version to 0.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-azureterraform",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-azureterraform",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@azure/arm-resources": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-azureterraform",
   "displayName": "Microsoft Terraform",
   "description": "VS Code extension for developing with Terraform on Azure",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "publisher": "ms-azuretools",
   "aiKey": "ae482601-060f-4c71-8567-ebd5085483c9",
   "appInsightsConnectionString": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
## Summary
- Bump the extension version from 0.10.2 to 0.10.3 in package metadata and lockfile.

## Testing
- Verified the version change in package.json and package-lock.json.