### PR TITLE
Bump version to 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ documented in this file.
 Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on
 how to structure this file.
 
+## [0.10.4]
+
+### Changed for 0.10.4
+
+- Updated `ms-terraform-lsp` to `v0.10.0`
+- Updated package dependencies:
+  - `@typescript-eslint/eslint-plugin`: `^8.62.1` → `^8.67.0`
+  - `@typescript-eslint/parser`: `^8.62.1` → `^8.67.0`
+  - `@types/lodash`: `^4.17.24` → `^4.17.25`
+  - `axios`: `^1.18.1` → `^1.19.0`
+  - `esbuild`: `^0.28.1` → `^0.28.2`
+  - `eslint`: `^10.6.0` → `^10.8.1`
+  - `mocha`: `^11.7.6` → `^11.8.0`
+  - `prettier`: `^3.9.3` → `^3.9.6`
+  - `typescript-eslint`: `^8.62.1` → `^8.67.0`
+
+### Fixed for 0.10.4
+
+- Bump `brace-expansion` to `5.0.9` to resolve CVEs. ([#364](https://github.com/Azure/vscode-azureterraform/pull/364))
+
 ## [0.10.3]
 
 ### Changed for 0.10.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-azureterraform",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-azureterraform",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@azure/arm-resources": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-azureterraform",
   "displayName": "Microsoft Terraform",
   "description": "VS Code extension for developing with Terraform on Azure",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "publisher": "ms-azuretools",
   "aiKey": "ae482601-060f-4c71-8567-ebd5085483c9",
   "appInsightsConnectionString": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
## Summary
- Bump the version from 0.10.3 to 0.10.4 in package metadata and lockfile. `CHANGELOG.md` is updated.

## Testing
- Verified the version change in `package.json` and `package-lock.json`.